### PR TITLE
Added correlation-types to DR2 Lya BAO default config

### DIFF
--- a/picca_bookkeeper/resources/default_configs/loa_v2.yaml
+++ b/picca_bookkeeper/resources/default_configs/loa_v2.yaml
@@ -292,6 +292,9 @@ fits:
   rmax xcf:
 
   extra args:
+    smooth_covariance:
+      general:
+        correlation-types: auto auto cross cross  
     vega_auto:
       general:
         cuts:


### PR DESCRIPTION
@m-herbold - I added the extra variable needed to the DR2 Lya BAO defaults file, since I think it was still missing. 

Could you check that this is indeed how this is supposed to be implemented? I copied it from the FS equivalent. 

By the way, the "reproduce dr2" instructions suggest you can copy these files from NERSC, but unfortunately those files are no longer valid because they don't have this variable set. 

I think this is ok, since the files at NERSC should be considered read-only, and reflect what was actually used at the time. I would just modify the instructions to point to files in this repo, that we can update if needed. 
